### PR TITLE
chore: configure VS Code to use project's TypeScript version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}


### PR DESCRIPTION
•  Added `.vscode/settings.json` to specify the TypeScript SDK path
•  Ensures VS Code uses the TypeScript version from `node_modules` for better compatibility with Next.js plugins and code suggestions

---

**Stack**:
- #14
- #13 ⬅
- #12


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*